### PR TITLE
Suggest ejecting installer DMGs using Disk Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ sudo xattr -rc /Applications/VMware\ Fusion.app/Contents/Library/Create\ Maveric
 ```
 You should be able to drag and drop the .app onto Fusion to begin the installation.
 
-If you're still having problems a reboot sometimes helps.
+If you're still having problems, open Disk Utility and eject any macOS
+installer disk images. Failing that, a reboot sometimes helps.
 
 
 There's more info on usage at our blog post [here](http://blogs.vmware.com/teamfusion/2016/06/fix-for-installing-macos-sierra-as-a-vm.html)


### PR DESCRIPTION
I ran into a number of errors getting this script to work—nearly all my own fault, e.g., permissions—but once everything was ironed out and *should* have worked, I still got “Unable to create the installation medium.”

The issue turned out to be that after a failed run, an install DMG was still mounted at a temporary path, and the script would break trying to `hdiutil attach` the same DMG at a different temporary path. Ejecting the DMG at that point works and saves you a reboot, so I’m hoping the README can suggest that.

This could be automated but my trying to parse `hdiutil info -plist` output in bash seems more likely to hurt than help here.