### PR TITLE
Support for High Sierra installation media

### DIFF
--- a/Create Mavericks Installer.tool
+++ b/Create Mavericks Installer.tool
@@ -79,7 +79,7 @@ hdiutil \
 # Mount BaseSystem.dmg so we can access files inside.
 # This fails if the image is already mounted somewhere else.
 hdiutil \
-   attach "$installMnt"/BaseSystem.dmg \
+   attach "$inputApp"/Contents/SharedSupport/BaseSystem.dmg \
    -mountpoint "$baseMnt" \
    -nobrowse \
    -noverify \

--- a/Create Mavericks Installer.tool
+++ b/Create Mavericks Installer.tool
@@ -78,12 +78,22 @@ hdiutil \
 
 # Mount BaseSystem.dmg so we can access files inside.
 # This fails if the image is already mounted somewhere else.
-hdiutil \
-   attach "$inputApp"/Contents/SharedSupport/BaseSystem.dmg \
-   -mountpoint "$baseMnt" \
-   -nobrowse \
-   -noverify \
-   -readonly
+if [ -f "$inputApp"/Contents/SharedSupport/BaseSystem.dmg ];
+then
+   hdiutil \
+      attach "$inputApp"/Contents/SharedSupport/BaseSystem.dmg \
+      -mountpoint "$baseMnt" \
+      -nobrowse \
+      -noverify \
+      -readonly
+else
+   hdiutil \
+      attach "$installMnt"/BaseSystem.dmg \
+      -mountpoint "$baseMnt" \
+      -nobrowse \
+      -noverify \
+      -readonly
+fi
 
 #
 # Determine the size of the disk image.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-## UPDATE: This fix is no longer required if you have Fusion 8.5, the fix is included ##
-
-This file resolves a failure when creating a new VM from the "Install 10.12 Developer Preview.app" 
+This file resolves a failure when creating a new VM from the "Install macOS High Sierra.app" package.
 
 The file "Create Mavericks Installer.tool" must replace the existing one located in: /Applications/VMware Fusion.app/Contents/Library/
 
@@ -12,6 +10,5 @@ sudo xattr -rc /Applications/VMware\ Fusion.app/Contents/Library/Create\ Maveric
 You should be able to drag and drop the .app onto Fusion to begin the installation.
 
 If you're still having problems a reboot sometimes helps.
-
 
 There's more info on usage at our blog post [here](http://blogs.vmware.com/teamfusion/2016/06/fix-for-installing-macos-sierra-as-a-vm.html)


### PR DESCRIPTION
The High Sierra install media from the App Store has a slightly different structure to previous releases of macOS - "BaseSystem.dmg" is now in the same location as "InstallESD.dmg", not inside it. This pull request fixes the script to allow the creation of High Sierra VMs using the "Install macOS High Sierra.app" install package from the App Store. 

Unlike pull request #9, this script checks the existence of the file in the new location and will fall back to the previous path if not.